### PR TITLE
Foresee logic to include test firm id in run-test action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Node v18
+      - name: Setup Node v20
         uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Description

Include a summary of the changes made

If test firm id is present in the config of a template, that will be the preferred option. 
If this is not the case, we can fall back to the repo variable (1 variable that can be set for the entire repo).
If this is not set either, we fall back to the default behaviour. 

Fixes # (link to the corresponding issue)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
