### PR TITLE
Update check_auth workflow to refresh partner API key

### DIFF
--- a/.github/workflows/check_auth.yml
+++ b/.github/workflows/check_auth.yml
@@ -34,13 +34,19 @@ jobs:
           echo '${{ secrets.CONFIG_JSON }}' > $HOME/.silverfin/config.json
       - name: Refresh tokens
         run: |
-          CONFIG_JSON=$(cat $HOME/.silverfin/config.json)
-          for FIRM_ID in $(echo $CONFIG_JSON | jq 'del(.defaultFirmIDs, .host) | keys[]'); do
-            FIRM_ID=$(echo $FIRM_ID | tr -d '"')
+          CONFIG_PATH="$HOME/.silverfin/config.json"
+          CONFIG_JSON=$(cat "$CONFIG_PATH")
+          for FIRM_ID in $(echo "$CONFIG_JSON" | jq 'del(.defaultFirmIDs, .host) | keys[]'); do
+            FIRM_ID=$(echo "$FIRM_ID" | tr -d '"')
             if [[ -n "$FIRM_ID" && "$FIRM_ID" =~ ^[0-9]+$  ]]; then
               echo "[Action] refreshing token for firm $FIRM_ID"
-              node ./node_modules/silverfin-cli/bin/cli.js config --refresh-token $FIRM_ID
+              node ./node_modules/silverfin-cli/bin/cli.js config --refresh-token "$FIRM_ID"
             fi
+          done
+          CONFIG_JSON=$(cat "$CONFIG_PATH")
+          for PARTNER_ID in $(echo "$CONFIG_JSON" | jq -r '.partnerCredentials // {} | keys[]'); do
+            echo "[Action] refreshing partner API key for partner $PARTNER_ID"
+            node ./node_modules/silverfin-cli/bin/cli.js config --refresh-partner-token "$PARTNER_ID"
           done
       - name: Prepare and store updated CONFIG_JSON as secret
         run: |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ _Steps:_
 * Installs the latest silverfin-cli version
 * Loads the CONFIG_JSON file from the secrets
 * Refreshes the tokens for all configured firms
+* Refreshes partner API keys for each key in `partnerCredentials` when that object is present (otherwise skips)
 * Updates the CONFIG_JSON file secret with the refreshed tokens
 
 


### PR DESCRIPTION
## Description

First step in building the CI pipeline: making sure that the partner environments are authorised as part of the authorisation workflow. 

Partner IDs are currently not yet included in our CONFIG_JSON variable (we only do firms). This will need to be added for this to work. 

Fixes # (link to the corresponding issue)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
