### PR TITLE
fix(ci): check_dependencies - remove check_auth run

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -3,8 +3,7 @@
 # Reusable workflow: call from a consumer repo with pull_request (labeled) and/or workflow_dispatch.
 #
 # Does not run check_auth: that job updates CONFIG_JSON via gh secret set, which notifies
-# repo/org admins by email. The silverfin-cli still requires SF_API_CLIENT_ID / SF_API_SECRET
-# in the environment to start (even for check-dependencies / version).
+# repo/org admins by email. check-dependencies only scans local Liquid Test YAML files.
 name: Check dependencies
 run-name: Check dependencies for changed reconciliation templates
 on:
@@ -25,8 +24,6 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CALL_PR_NUMBER: ${{ inputs.pull_request_number }}
-      SF_API_CLIENT_ID: ${{ secrets.SF_API_CLIENT_ID }}
-      SF_API_SECRET: ${{ secrets.SF_API_SECRET }}
     steps:
       # Resolve PR base and head SHAs (head used for checkout so scans match the PR branch)
       - name: Get PR details
@@ -146,7 +143,6 @@ jobs:
         if: steps.handles.outputs.handles_json != '[]'
         run: |
           npm install https://github.com/silverfin/silverfin-cli.git
-          node ./node_modules/silverfin-cli/bin/cli.js -V
 
       # Run check-dependencies for each handle and collect results
       - name: Run check-dependencies per handle

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -3,8 +3,8 @@
 # Reusable workflow: call from a consumer repo with pull_request (labeled) and/or workflow_dispatch.
 #
 # Does not run check_auth: that job updates CONFIG_JSON via gh secret set, which notifies
-# repo/org admins by email. The CLI check-dependencies command only scans local Liquid Test
-# YAML files and does not need API credentials.
+# repo/org admins by email. The silverfin-cli still requires SF_API_CLIENT_ID / SF_API_SECRET
+# in the environment to start (even for check-dependencies / version).
 name: Check dependencies
 run-name: Check dependencies for changed reconciliation templates
 on:
@@ -25,6 +25,8 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CALL_PR_NUMBER: ${{ inputs.pull_request_number }}
+      SF_API_CLIENT_ID: ${{ secrets.SF_API_CLIENT_ID }}
+      SF_API_SECRET: ${{ secrets.SF_API_SECRET }}
     steps:
       # Resolve PR base and head SHAs (head used for checkout so scans match the PR branch)
       - name: Get PR details

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -139,11 +139,6 @@ jobs:
               });
             }
 
-      - name: Setup Node and Silverfin CLI
-        if: steps.handles.outputs.handles_json != '[]'
-        run: |
-          npm install https://github.com/silverfin/silverfin-cli.git
-
       # Run check-dependencies for each handle and collect results
       - name: Run check-dependencies per handle
         id: run-check
@@ -151,6 +146,7 @@ jobs:
         env:
           HANDLES_JSON: ${{ steps.handles.outputs.handles_json }}
         run: |
+          npm install https://github.com/silverfin/silverfin-cli.git
           job_failed=0
           : > check_results.txt
           while IFS= read -r handle; do


### PR DESCRIPTION
## Summary
The **Check dependencies** reusable workflow failed during setup because it ran `silverfin-cli -V` after `npm install`. That invocation triggers the CLI’s credential check, even though **`check-dependencies` only scans local Liquid test YAML** and does not need Silverfin API access for that work.
This PR **removes the unnecessary `cli.js -V` call** and keeps setup as **install only**, before running `check-dependencies` per handle.

## Changes
- Remove `node ./node_modules/silverfin-cli/bin/cli.js -V` from the “Setup Node and Silverfin CLI” step.
- Adjust the header comment to match (local scan only; no `check_auth` / token refresh in this workflow).

## Notes
- This avoids wiring `SF_API_CLIENT_ID` / `SF_API_SECRET` into this workflow solely to satisfy a redundant version check.
- If `silverfin-cli check-dependencies` itself enforces credentials at runtime in the future, that would be a separate CLI/product concern; this change only removes the extra step that caused the failure you observed.