### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatibility

### DIFF
--- a/.github/workflows/check_auth.yml
+++ b/.github/workflows/check_auth.yml
@@ -17,9 +17,9 @@ jobs:
       SF_API_SECRET: "${{ secrets.SF_API_SECRET }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Add silverfin-cli package latest version

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Check out PR HEAD (config.json / template tree for check-dependencies must match the PR)
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr-details.outputs.head_sha }}
 

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Step 1: Checkout the repository @ $GITHUB_WORKSPACE so workflow can access it
       - name: Checkout Repository - Fetch history of the current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Current branch only
           ref: ${{ github.ref }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,16 +21,16 @@ jobs:
       changed_templates: ${{ steps.templates_changed.outputs.changed_templates }}
     steps:
       - name: Checkout Repository - Fetch all history for all tags and branches
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get changed liquid files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v46
         with:
           since_last_remote_commit: false
           dir_names: false
-          ref: "main"
+          base_sha: 'main'
           files: |
             **/**.{liquid,yml,yaml,json}
       - name: Filter templates changed
@@ -76,13 +76,13 @@ jobs:
     needs: [check-auth, check-changed-templates]
     steps:
       - name: Checkout Repository - Fetch all history for all tags and branches
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup Node v20
-        uses: actions/setup-node@v4
+      - name: Setup Node v22
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
       - name: Load Silverfin config file from secrets
         run: |
           mkdir -p $HOME/.silverfin/

--- a/.github/workflows/slack_changelog.yml
+++ b/.github/workflows/slack_changelog.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/update_templates_production.yml
+++ b/.github/workflows/update_templates_production.yml
@@ -14,7 +14,7 @@ jobs:
       has_partner_deployment_label: ${{ steps.haslabel.outputs.labeled-3-deploy-to-partner }}
     steps:
       - name: Checkout Repository - Fetch all history for all tags and branches
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Labeled to partner deployment
@@ -29,7 +29,7 @@ jobs:
       changed_templates: ${{ steps.templates_changed.outputs.changed_templates }}
     steps:
       - name: Checkout Repository - Fetch all history for all tags and branches
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get changed liquid files


### PR DESCRIPTION
## Summary

- **Deadline: June 16, 2026** — all caller repos (be_market and others) inherit this fix automatically via `uses: silverfin/bso_github_actions/.github/workflows/...`
- `actions/checkout` v4 → v6 across all 6 workflow files
- `actions/setup-node` v4 → v6 in `run_tests.yml` and `check_auth.yml`
- `tj-actions/changed-files` v41 → v46 in `run_tests.yml`
- Replaced deprecated `ref: "main"` with `base_sha: 'main'` in `run_tests.yml` (the `ref` input was removed in v43+; `check_tests.yml` already used v46 with `base_sha: 'main'` as the correct pattern)
- `node-version: 20` → `node-version: 22` in `run_tests.yml`

## Files changed

| File | Changes |
|------|---------|
| `.github/workflows/run_tests.yml` | checkout v6, changed-files v46, `ref` → `base_sha`, setup-node v6, node 20 → 22 |
| `.github/workflows/check_auth.yml` | checkout v6, setup-node v6 |
| `.github/workflows/check_tests.yml` | checkout v6 |
| `.github/workflows/check_dependencies.yml` | checkout v6 |
| `.github/workflows/slack_changelog.yml` | checkout v6 |
| `.github/workflows/update_templates_production.yml` | checkout v6 (×2) |

## Test plan

- [ ] Verify a PR in a caller repo (e.g. be_market) triggers `run_tests.yml` and the changed-files step resolves correctly with `base_sha: 'main'`
- [ ] Confirm `check_auth.yml` runs Node 22 without errors
- [ ] Confirm `check_tests.yml`, `check_dependencies.yml`, `slack_changelog.yml`, and `update_templates_production.yml` still pass after the checkout bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)