### PR TITLE
Bump tj-actions/changed-files v46 → v47 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -21,7 +21,7 @@ jobs:
       # Step 2: Get changed YAML files
       - name: Get changed YAML files
         id: get-changed-yaml-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           # Compare against the main branch
           base_sha: 'main'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed liquid files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           since_last_remote_commit: false
           dir_names: false

--- a/.github/workflows/update_templates_production.yml
+++ b/.github/workflows/update_templates_production.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed liquid files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           since_last_remote_commit: false
           dir_names: false


### PR DESCRIPTION
## Summary

- Bumps `tj-actions/changed-files` from `v46` to `v47` across `run_tests.yml`, `check_tests.yml`, and `update_templates_production.yml`
- v47 upgrades the action's internal runtime to Node.js 24, resolving the deprecation warning introduced after the previous PR was merged

## Test plan

- [ ] Verify no deprecation warnings appear in the `check-changed-templates` job after merge
- [ ] Confirm `run-tests` workflow behaves as before on a PR with changed templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)