### PR TITLE
feat(ci): run liquid tests in parallel, grouped per firm and template type

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -118,11 +118,11 @@ jobs:
           # (which contain spaces and other characters) stay intact.
           declare -A TEMPLATE_BUCKETS
           declare -a ERRORS
+          declare -a SUMMARY
           # CHANGED_TEMPLATES is a JSON array; read it space-safely. The process substitution
           # keeps the loop in the current shell so the arrays above survive.
           while IFS= read -r CURRENT_DIR; do
             [[ -z "${CURRENT_DIR}" ]] && continue
-            echo "Checking ${CURRENT_DIR}"
             while [[ "${CURRENT_DIR}" != "." ]]; do
               if [[ -e "${CURRENT_DIR}/config.json" ]]; then
                 # Decide the template type from the path. Only reconciliation_texts and
@@ -172,7 +172,6 @@ jobs:
                   
                   if [[ "$FOUND_MATCH" == "true" ]]; then
                     FIRM_ID="$TEST_FIRM_ID"
-                    echo "Using configured test_firm_id: ${FIRM_ID}"
                   else
                     echo "Warning: test_firm_id '${TEST_FIRM_ID}' not found in .id object, falling back to environment variable or default"
                   fi
@@ -193,7 +192,6 @@ jobs:
                   
                   if [[ "$FOUND_MATCH" == "true" ]]; then
                     FIRM_ID="$SF_TEST_FIRM_ID"
-                    echo "Using SF_TEST_FIRM_ID environment variable: ${FIRM_ID}"
                   else
                     echo "Warning: SF_TEST_FIRM_ID '${SF_TEST_FIRM_ID}' not found in .id object, falling back to default"
                   fi
@@ -202,14 +200,13 @@ jobs:
                 if [[ -z "$FIRM_ID" ]]; then
                   # 3. Default behavior - use first available firm ID
                   FIRM_ID=$(cat "${CURRENT_DIR}/config.json" | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
-                  echo "Using first available firm ID: ${FIRM_ID}"
                 fi
-                
+
                 # Group this template under "<firm>|<type>" so all templates that share a firm
                 # and type run together in one parallel batch. Newline-separated keeps identifiers
                 # that contain spaces (account template names) intact.
                 TEMPLATE_BUCKETS["${FIRM_ID}|${TEMPLATE_TYPE}"]+="${IDENTIFIER}"$'\n'
-                echo "Queued ${IDENTIFIER} (${TEMPLATE_TYPE}) for firm ${FIRM_ID}"
+                echo "+ ${IDENTIFIER} → firm ${FIRM_ID}"
                 break
               else
                 echo "Config file not found in ${CURRENT_DIR}"
@@ -233,10 +230,11 @@ jobs:
             # spaces stay intact).
             mapfile -t IDENTIFIERS < <(printf '%s' "${TEMPLATE_BUCKETS[$KEY]}" | sort -u | grep -v '^$')
             TOTAL=${#IDENTIFIERS[@]}
-            echo "Firm ${FIRM_ID} / ${TEMPLATE_TYPE}: ${TOTAL} template(s) to test"
             for (( START=0; START<TOTAL; START+=MAX_PARALLEL )); do
               BATCH=("${IDENTIFIERS[@]:START:MAX_PARALLEL}")
-              echo "Running batch for firm ${FIRM_ID} / ${TEMPLATE_TYPE} (${#BATCH[@]} in parallel): ${BATCH[*]}"
+              # Fold each parallel batch into a collapsible log group so the raw CLI output
+              # (spinner frames included) stays out of the way unless you open it.
+              echo "::group::firm ${FIRM_ID} · ${TEMPLATE_TYPE} · ${#BATCH[@]} in parallel"
               if OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --firm "${FIRM_ID}" --status ${CLI_FLAG} "${BATCH[@]}" 2>&1); then
                 BATCH_EXIT=0
               else
@@ -247,33 +245,49 @@ jobs:
               # and the test spinner interleaves frames via carriage returns, so split on carriage
               # returns and strip ANSI escapes first. We then read the top-level
               # "[log] <name>: PASSED|FAILED" lines (a leading space after "[log] " marks an
-              # indented sub-result, which is skipped) and match by EXACT name: account template
-              # names contain spaces and characters that are unsafe inside a regex.
+              # indented sub-result, which is skipped; trailing whitespace is tolerated) and match
+              # by EXACT name: account template names contain spaces and characters that are
+              # unsafe inside a regex.
               CLEAN_OUTPUT=$(printf '%s\n' "${OUTPUT}" | tr '\r' '\n' | sed -E $'s/\033\\[[0-9;?]*[A-Za-z]//g')
               declare -A RESULTS=()
               while IFS= read -r LINE; do
                 STATUS="${LINE##*: }"
+                STATUS="${STATUS%%[[:space:]]*}"
                 NAME="${LINE#\[log\] }"
                 NAME="${NAME%: *}"
                 RESULTS["${NAME}"]="${STATUS}"
-              done < <(printf '%s\n' "${CLEAN_OUTPUT}" | grep -oE '\[log\] [^[:space:]].*: (PASSED|FAILED)$')
+              done < <(printf '%s\n' "${CLEAN_OUTPUT}" | grep -oE '\[log\] [^[:space:]].*: (PASSED|FAILED)[[:space:]]*$')
               for IDENTIFIER in "${BATCH[@]}"; do
                 case "${RESULTS[${IDENTIFIER}]:-}" in
                   PASSED)
                     echo "${IDENTIFIER}: passed"
+                    SUMMARY+=("PASS"$'\t'"${FIRM_ID}"$'\t'"${IDENTIFIER}")
                     ;;
                   FAILED)
                     echo "${IDENTIFIER}: failed"
                     ERRORS+=("${IDENTIFIER}")
+                    SUMMARY+=("FAIL"$'\t'"${FIRM_ID}"$'\t'"${IDENTIFIER}")
                     ;;
                   *)
                     echo "${IDENTIFIER}: status could not be determined (batch exit code ${BATCH_EXIT})"
                     ERRORS+=("${IDENTIFIER}")
+                    SUMMARY+=("????"$'\t'"${FIRM_ID}"$'\t'"${IDENTIFIER}")
                     ;;
                 esac
               done
+              echo "::endgroup::"
             done
           done
+          # Flat summary keyed on the two columns that matter: template and firm.
+          if [ ${#SUMMARY[@]} -gt 0 ]; then
+            echo ""
+            echo "─ Results ─────────────────────────────────────────────────────"
+            while IFS=$'\t' read -r RESULT FIRM NAME; do
+              printf ' %-4s %-45s firm %s\n' "${RESULT}" "${NAME}" "${FIRM}"
+            done < <(printf '%s\n' "${SUMMARY[@]}")
+            echo "────────────────────────────────────────────────────────────────"
+            echo "${#ERRORS[@]} failed, $(( ${#SUMMARY[@]} - ${#ERRORS[@]} )) passed"
+          fi
           # CHECK ERRORS PRESENT
           if [ ${#ERRORS[@]} -eq 0 ]; then
               echo "All tests have passed"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -199,13 +199,17 @@ jobs:
                 BATCH_EXIT=$?
               fi
               echo "${OUTPUT}"
-              # Strip ANSI colour codes so the per-handle status lines can be parsed reliably.
-              CLEAN_OUTPUT=$(printf '%s\n' "${OUTPUT}" | sed -E "s/\x1b\[[0-9;]*m//g")
-              # The CLI prints one top-level "<handle>: PASSED" / "<handle>: FAILED" line per handle.
+              # Normalise the output before parsing: split carriage-return spinner frames onto
+              # their own lines and strip ANSI / cursor escape sequences. In CI, consola prefixes
+              # every line with a "[log] " tag and the test spinner interleaves frames onto the
+              # same line, so the per-handle status ("<handle>: PASSED") is not at the start of a
+              # line. Match the handle on a left word boundary instead of anchoring to "^".
+              CLEAN_OUTPUT=$(printf '%s\n' "${OUTPUT}" | tr '\r' '\n' | sed -E $'s/\033\\[[0-9;?]*[A-Za-z]//g')
+              # The CLI prints one "<handle>: PASSED" / "<handle>: FAILED" line per handle.
               for HANDLE in "${BATCH[@]}"; do
-                if printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "^[[:space:]]*${HANDLE}: PASSED[[:space:]]*$"; then
+                if printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "(^|[^[:alnum:]_])${HANDLE}: PASSED"; then
                   echo "${HANDLE}: passed"
-                elif printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "^[[:space:]]*${HANDLE}: FAILED[[:space:]]*$"; then
+                elif printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "(^|[^[:alnum:]_])${HANDLE}: FAILED"; then
                   echo "${HANDLE}: failed"
                   ERRORS+=("${HANDLE}")
                 else

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,6 +24,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Emit non-ASCII paths raw
+        # With git's default core.quotepath=true, paths with non-ASCII characters (e.g. a curly
+        # apostrophe in an account template name) are emitted octal-escaped and silently dropped
+        # by the changed-files glob filter, so the template would never be tested.
+        run: git config --global core.quotepath false
       - name: Get changed liquid files
         id: changed-files
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
@@ -34,8 +39,12 @@ jobs:
           # Emit the file list as a JSON array so paths containing spaces (e.g. account
           # template names) survive the hand-off between steps and jobs intact.
           # escape_json: false keeps it valid JSON for jq (the default double-escapes the quotes).
+          # safe_output: false stops backslash-escaping of shell metacharacters (& ( ) ...) inside
+          # the JSON values, which is invalid JSON and would silently empty the template list.
+          # Safe here: the list is passed via env and parsed with jq, never eval'd by the shell.
           json: true
           escape_json: false
+          safe_output: false
           files: |
             **/**.{liquid,yml,yaml,json}
       - name: Filter templates changed
@@ -45,8 +54,16 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # all_changed_files is a JSON array (json: true). Extract the unique template
-          # directories (reconciliation_texts / account_templates / shared_parts), space-safely.
-          pattern='(reconciliation_texts|account_templates|shared_parts)/[^/]+'
+          # directories, space-safely. Only reconciliation_texts and account_templates have
+          # liquid tests; shared_parts is left out so a shared-parts-only PR skips the test
+          # job entirely instead of spinning it up just to skip every template.
+          pattern='(reconciliation_texts|account_templates)/[^/]+'
+          # Fail loudly if the changed-files output is not valid JSON. A silent jq failure
+          # here would empty the template list and skip every test while CI stays green.
+          if ! printf '%s' "${ALL_CHANGED_FILES:-[]}" | jq -e . > /dev/null; then
+            echo "::error::changed-files output is not valid JSON, refusing to skip tests silently"
+            exit 1
+          fi
           mapfile -t changed_templates < <(printf '%s' "${ALL_CHANGED_FILES:-[]}" | jq -r '.[]' | grep -oE "$pattern" | sort -u)
           if [ ${#changed_templates[@]} -eq 0 ]; then
             echo "No templates changed"
@@ -109,8 +126,8 @@ jobs:
             while [[ "${CURRENT_DIR}" != "." ]]; do
               if [[ -e "${CURRENT_DIR}/config.json" ]]; then
                 # Decide the template type from the path. Only reconciliation_texts and
-                # account_templates have liquid tests; skip anything else (e.g. shared_parts,
-                # whose ".id" is a plain string) before resolving a firm.
+                # account_templates have liquid tests; the filter step already excludes other
+                # types, this branch is defense in depth.
                 if [[ "${CURRENT_DIR}" == *reconciliation_texts* ]]; then
                   TEMPLATE_TYPE="reconciliationText"
                   IDENTIFIER=$(cat "${CURRENT_DIR}/config.json" | jq -r ".handle // .name")
@@ -122,7 +139,18 @@ jobs:
                   echo "Skipping ${CURRENT_DIR} (no liquid tests for this template type)"
                   break
                 fi
-                
+
+                # Skip templates whose test YAML is missing or has no real content. The CLI
+                # reports those as FAILED ("there are no tests stored in the YAML file"), and a
+                # template without tests should not fail CI.
+                TEST_REL=$(cat "${CURRENT_DIR}/config.json" | jq -r '.test // empty')
+                TEST_PATH="${CURRENT_DIR}/${TEST_REL}"
+                if [[ -z "${TEST_REL}" || ! -s "${TEST_PATH}" ]] \
+                   || [[ "$(grep -cvE '^[[:space:]]*(#|$)' "${TEST_PATH}")" -eq 0 ]]; then
+                  echo "Skipping ${IDENTIFIER} (no liquid tests defined)"
+                  break
+                fi
+
                 # Initialize FIRM_ID
                 FIRM_ID=""
                 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,39 +31,31 @@ jobs:
           since_last_remote_commit: false
           dir_names: false
           base_sha: 'main'
+          # Emit the file list as a JSON array so paths containing spaces (e.g. account
+          # template names) survive the hand-off between steps and jobs intact.
+          json: true
           files: |
             **/**.{liquid,yml,yaml,json}
       - name: Filter templates changed
         id: templates_changed
+        env:
+          # Passed via env (not inlined) so a path with quotes/spaces cannot break the script.
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          pattern="(?:reconciliation_texts|shared_parts)/([^/]+)/"
-          changed_files="${{ steps.changed-files.outputs.all_changed_files }}"
-          if [ -n "$changed_files" ]; then
-            filtered_names=($(printf "%s\n" "$changed_files" | grep -oP "$pattern" || true))
-            if [ $? -ne 0 ]; then
-              echo "No files match the pattern"
-              changed_templates=()
-            else
-              # Remove the trailing "/" from the extracted names
-              filtered_names=("${filtered_names[@]%/}")
-              # Remove duplicates
-              changed_templates=($(printf "%s\n" "${filtered_names[@]}" | sort -u))
-            fi
-          else
-            echo "No changed files"
-            changed_templates=()
-          fi
-          # Store outputs
+          # all_changed_files is a JSON array (json: true). Extract the unique template
+          # directories (reconciliation_texts / account_templates / shared_parts), space-safely.
+          pattern='(reconciliation_texts|account_templates|shared_parts)/[^/]+'
+          mapfile -t changed_templates < <(printf '%s' "${ALL_CHANGED_FILES:-[]}" | jq -r '.[]' | grep -oE "$pattern" | sort -u)
           if [ ${#changed_templates[@]} -eq 0 ]; then
-            echo "changed_templates=[]" >> $GITHUB_OUTPUT
+            echo "No templates changed"
+            echo "changed_templates=[]" >> "$GITHUB_OUTPUT"
           else
-            echo "changed_templates=${changed_templates[*]}" >> $GITHUB_OUTPUT
-            # Print the templates names
-            for name in "${changed_templates[@]}"; do
-              echo "$name"
-            done
+            echo "Changed templates:"
+            printf '  %s\n' "${changed_templates[@]}"
+            # Emit a JSON array so directory names containing spaces survive as single entries.
+            json=$(printf '%s\n' "${changed_templates[@]}" | jq -R . | jq -s -c .)
+            echo "changed_templates=${json}" >> "$GITHUB_OUTPUT"
           fi
-          exit 0
 
   test-templates:
     runs-on: ubuntu-latest
@@ -101,30 +93,43 @@ jobs:
       - name: Run liquid tests for updated templates (grouped per firm, run in parallel)
         run: |
           MAX_PARALLEL="${MAX_PARALLEL_TESTS:-5}"
-          # Reconciliation handles grouped by their resolved firm id ("firm id" -> "handle1 handle2 ...").
-          declare -A FIRM_HANDLES
+          # Testable templates grouped by "<firm id>|<template type>". Each bucket maps to one
+          # `run-test` call, because the CLI takes a single firm and a single template type per
+          # invocation. Identifiers are stored newline-separated so account template names
+          # (which contain spaces and other characters) stay intact.
+          declare -A TEMPLATE_BUCKETS
           declare -a ERRORS
-          for CURRENT_DIR in ${{ env.CHANGED_TEMPLATES }}; do
+          # CHANGED_TEMPLATES is a JSON array; read it space-safely. The process substitution
+          # keeps the loop in the current shell so the arrays above survive.
+          while IFS= read -r CURRENT_DIR; do
+            [[ -z "${CURRENT_DIR}" ]] && continue
             echo "Checking ${CURRENT_DIR}"
             while [[ "${CURRENT_DIR}" != "." ]]; do
               if [[ -e "${CURRENT_DIR}/config.json" ]]; then
-                # Only reconciliation_texts have liquid tests executed in CI; skip anything
-                # else (e.g. shared_parts, whose ".id" is a plain string) before resolving a firm.
-                if [[ "${CURRENT_DIR}" != *reconciliation_texts* ]]; then
-                  echo "Skipping ${CURRENT_DIR} (not a reconciliation template)"
+                # Decide the template type from the path. Only reconciliation_texts and
+                # account_templates have liquid tests; skip anything else (e.g. shared_parts,
+                # whose ".id" is a plain string) before resolving a firm.
+                if [[ "${CURRENT_DIR}" == *reconciliation_texts* ]]; then
+                  TEMPLATE_TYPE="reconciliationText"
+                  IDENTIFIER=$(cat "${CURRENT_DIR}/config.json" | jq -r ".handle // .name")
+                elif [[ "${CURRENT_DIR}" == *account_templates* ]]; then
+                  TEMPLATE_TYPE="accountTemplate"
+                  # Account template configs often have a null handle/name, so use the folder name.
+                  IDENTIFIER=$(basename "${CURRENT_DIR}")
+                else
+                  echo "Skipping ${CURRENT_DIR} (no liquid tests for this template type)"
                   break
                 fi
-                HANDLE=$(cat ${CURRENT_DIR}/config.json | jq -r ".handle // .name")
                 
                 # Initialize FIRM_ID
                 FIRM_ID=""
                 
                 # Check if test_firm_id is present in config
-                TEST_FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".test_firm_id // empty")
+                TEST_FIRM_ID=$(cat "${CURRENT_DIR}/config.json" | jq -r ".test_firm_id // empty")
 
                 if [[ -n "$TEST_FIRM_ID" && "$TEST_FIRM_ID" != "null" ]]; then
                   # 1. Template-specific test_firm_id (highest priority)
-                  AVAILABLE_FIRM_IDS=$(cat ${CURRENT_DIR}/config.json | jq -r ".id | keys[]" 2>/dev/null || echo "")
+                  AVAILABLE_FIRM_IDS=$(cat "${CURRENT_DIR}/config.json" | jq -r ".id | keys[]" 2>/dev/null || echo "")
                   
                   # Check for exact match by looping through available IDs
                   FOUND_MATCH=false
@@ -145,7 +150,7 @@ jobs:
                 
                 if [[ -z "$FIRM_ID" && -n "$SF_TEST_FIRM_ID" ]]; then
                   # 2. Environment variable fallback
-                  AVAILABLE_FIRM_IDS=$(cat ${CURRENT_DIR}/config.json | jq -r ".id | keys[]" 2>/dev/null || echo "")
+                  AVAILABLE_FIRM_IDS=$(cat "${CURRENT_DIR}/config.json" | jq -r ".id | keys[]" 2>/dev/null || echo "")
                   
                   # Check for exact match by looping through available IDs
                   FOUND_MATCH=false
@@ -166,56 +171,76 @@ jobs:
                 
                 if [[ -z "$FIRM_ID" ]]; then
                   # 3. Default behavior - use first available firm ID
-                  FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
+                  FIRM_ID=$(cat "${CURRENT_DIR}/config.json" | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
                   echo "Using first available firm ID: ${FIRM_ID}"
                 fi
                 
-                # Group this reconciliation under its resolved firm so all reconciliations
-                # for the same firm can be run together in a single parallel batch later.
-                FIRM_HANDLES["${FIRM_ID}"]+=" ${HANDLE}"
-                echo "Queued ${HANDLE} for firm ${FIRM_ID}"
+                # Group this template under "<firm>|<type>" so all templates that share a firm
+                # and type run together in one parallel batch. Newline-separated keeps identifiers
+                # that contain spaces (account template names) intact.
+                TEMPLATE_BUCKETS["${FIRM_ID}|${TEMPLATE_TYPE}"]+="${IDENTIFIER}"$'\n'
+                echo "Queued ${IDENTIFIER} (${TEMPLATE_TYPE}) for firm ${FIRM_ID}"
                 break
               else
                 echo "Config file not found in ${CURRENT_DIR}"
                 CURRENT_DIR="$(dirname "${CURRENT_DIR}")"
               fi
             done
-          done
-          # Run the queued reconciliations grouped per firm. All handles passed to a single
-          # `run-test --status` call are executed concurrently by the CLI (Promise.all), so we
-          # cap each batch at MAX_PARALLEL handles and run batches sequentially to keep the
-          # total number of in-flight tests against the live platform bounded.
-          for FIRM_ID in "${!FIRM_HANDLES[@]}"; do
-            # Deduplicate and sort the handles queued for this firm.
-            read -r -a HANDLES <<< "$(printf '%s\n' ${FIRM_HANDLES[$FIRM_ID]} | sort -u | tr '\n' ' ')"
-            TOTAL=${#HANDLES[@]}
-            echo "Firm ${FIRM_ID}: ${TOTAL} reconciliation(s) to test: ${HANDLES[*]}"
+          done < <(printf '%s' "${CHANGED_TEMPLATES}" | jq -r '.[]')
+          # Run each bucket. All identifiers passed to a single `run-test --status` call run
+          # concurrently in the CLI (Promise.all), so we cap each batch at MAX_PARALLEL and run
+          # batches sequentially to keep the number of in-flight tests against the platform bounded.
+          for KEY in "${!TEMPLATE_BUCKETS[@]}"; do
+            FIRM_ID="${KEY%%|*}"
+            TEMPLATE_TYPE="${KEY##*|}"
+            # The CLI uses a different flag per template type.
+            if [[ "${TEMPLATE_TYPE}" == "accountTemplate" ]]; then
+              CLI_FLAG="--account-template"
+            else
+              CLI_FLAG="--handle"
+            fi
+            # Deduplicate the identifiers for this bucket (newline-separated, so names with
+            # spaces stay intact).
+            mapfile -t IDENTIFIERS < <(printf '%s' "${TEMPLATE_BUCKETS[$KEY]}" | sort -u | grep -v '^$')
+            TOTAL=${#IDENTIFIERS[@]}
+            echo "Firm ${FIRM_ID} / ${TEMPLATE_TYPE}: ${TOTAL} template(s) to test"
             for (( START=0; START<TOTAL; START+=MAX_PARALLEL )); do
-              BATCH=("${HANDLES[@]:START:MAX_PARALLEL}")
-              echo "Running batch for firm ${FIRM_ID} (${#BATCH[@]} in parallel): ${BATCH[*]}"
-              if OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --firm "${FIRM_ID}" --status --handle "${BATCH[@]}" 2>&1); then
+              BATCH=("${IDENTIFIERS[@]:START:MAX_PARALLEL}")
+              echo "Running batch for firm ${FIRM_ID} / ${TEMPLATE_TYPE} (${#BATCH[@]} in parallel): ${BATCH[*]}"
+              if OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --firm "${FIRM_ID}" --status ${CLI_FLAG} "${BATCH[@]}" 2>&1); then
                 BATCH_EXIT=0
               else
                 BATCH_EXIT=$?
               fi
               echo "${OUTPUT}"
-              # Normalise the output before parsing: split carriage-return spinner frames onto
-              # their own lines and strip ANSI / cursor escape sequences. In CI, consola prefixes
-              # every line with a "[log] " tag and the test spinner interleaves frames onto the
-              # same line, so the per-handle status ("<handle>: PASSED") is not at the start of a
-              # line. Match the handle on a left word boundary instead of anchoring to "^".
+              # Parse the per-template status. In CI, consola prefixes every line with "[log] "
+              # and the test spinner interleaves frames via carriage returns, so split on carriage
+              # returns and strip ANSI escapes first. We then read the top-level
+              # "[log] <name>: PASSED|FAILED" lines (a leading space after "[log] " marks an
+              # indented sub-result, which is skipped) and match by EXACT name: account template
+              # names contain spaces and characters that are unsafe inside a regex.
               CLEAN_OUTPUT=$(printf '%s\n' "${OUTPUT}" | tr '\r' '\n' | sed -E $'s/\033\\[[0-9;?]*[A-Za-z]//g')
-              # The CLI prints one "<handle>: PASSED" / "<handle>: FAILED" line per handle.
-              for HANDLE in "${BATCH[@]}"; do
-                if printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "(^|[^[:alnum:]_])${HANDLE}: PASSED"; then
-                  echo "${HANDLE}: passed"
-                elif printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "(^|[^[:alnum:]_])${HANDLE}: FAILED"; then
-                  echo "${HANDLE}: failed"
-                  ERRORS+=("${HANDLE}")
-                else
-                  echo "${HANDLE}: status could not be determined (batch exit code ${BATCH_EXIT})"
-                  ERRORS+=("${HANDLE}")
-                fi
+              declare -A RESULTS=()
+              while IFS= read -r LINE; do
+                STATUS="${LINE##*: }"
+                NAME="${LINE#\[log\] }"
+                NAME="${NAME%: *}"
+                RESULTS["${NAME}"]="${STATUS}"
+              done < <(printf '%s\n' "${CLEAN_OUTPUT}" | grep -oE '\[log\] [^[:space:]].*: (PASSED|FAILED)$')
+              for IDENTIFIER in "${BATCH[@]}"; do
+                case "${RESULTS[${IDENTIFIER}]:-}" in
+                  PASSED)
+                    echo "${IDENTIFIER}: passed"
+                    ;;
+                  FAILED)
+                    echo "${IDENTIFIER}: failed"
+                    ERRORS+=("${IDENTIFIER}")
+                    ;;
+                  *)
+                    echo "${IDENTIFIER}: status could not be determined (batch exit code ${BATCH_EXIT})"
+                    ERRORS+=("${IDENTIFIER}")
+                    ;;
+                esac
               done
             done
           done

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,7 +70,7 @@ jobs:
       # A single `run-test --status` call fires all of its handles concurrently (Promise.all)
       # with no client-side rate limiting, so we cap the batch size and run batches
       # sequentially to keep the global number of in-flight tests bounded.
-      MAX_PARALLEL_TESTS: 5
+      MAX_PARALLEL_TESTS: 10
     if: ${{ needs.check-changed-templates.outputs.changed_templates != '[]' }}
     needs: [check-auth, check-changed-templates]
     steps:
@@ -94,7 +94,7 @@ jobs:
           echo "CLI version: ${VERSION}"
       - name: Run liquid tests for updated templates (grouped per firm, run in parallel)
         run: |
-          MAX_PARALLEL="${MAX_PARALLEL_TESTS:-5}"
+          MAX_PARALLEL="${MAX_PARALLEL_TESTS:-10}"
           # Testable templates grouped by "<firm id>|<template type>". Each bucket maps to one
           # `run-test` call, because the CLI takes a single firm and a single template type per
           # invocation. Identifiers are stored newline-separated so account template names

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,7 +33,9 @@ jobs:
           base_sha: 'main'
           # Emit the file list as a JSON array so paths containing spaces (e.g. account
           # template names) survive the hand-off between steps and jobs intact.
+          # escape_json: false keeps it valid JSON for jq (the default double-escapes the quotes).
           json: true
+          escape_json: false
           files: |
             **/**.{liquid,yml,yaml,json}
       - name: Filter templates changed

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,6 +72,11 @@ jobs:
       SF_API_SECRET: "${{ secrets.SF_API_SECRET }}"
       SF_TEST_FIRM_ID: "${{ vars.SF_TEST_FIRM_ID }}"
       CHANGED_TEMPLATES: "${{ needs.check-changed-templates.outputs.changed_templates }}"
+      # Maximum number of liquid tests run in parallel against the live platform per batch.
+      # A single `run-test --status` call fires all of its handles concurrently (Promise.all)
+      # with no client-side rate limiting, so we cap the batch size and run batches
+      # sequentially to keep the global number of in-flight tests bounded.
+      MAX_PARALLEL_TESTS: 5
     if: ${{ needs.check-changed-templates.outputs.changed_templates != '[]' }}
     needs: [check-auth, check-changed-templates]
     steps:
@@ -93,13 +98,22 @@ jobs:
           npm install https://github.com/silverfin/silverfin-cli.git
           VERSION=$(./node_modules/silverfin-cli/bin/cli.js -V)
           echo "CLI version: ${VERSION}"
-      - name: Run liquid tests for updated templates
+      - name: Run liquid tests for updated templates (grouped per firm, run in parallel)
         run: |
+          MAX_PARALLEL="${MAX_PARALLEL_TESTS:-5}"
+          # Reconciliation handles grouped by their resolved firm id ("firm id" -> "handle1 handle2 ...").
+          declare -A FIRM_HANDLES
           declare -a ERRORS
           for CURRENT_DIR in ${{ env.CHANGED_TEMPLATES }}; do
             echo "Checking ${CURRENT_DIR}"
             while [[ "${CURRENT_DIR}" != "." ]]; do
               if [[ -e "${CURRENT_DIR}/config.json" ]]; then
+                # Only reconciliation_texts have liquid tests executed in CI; skip anything
+                # else (e.g. shared_parts, whose ".id" is a plain string) before resolving a firm.
+                if [[ "${CURRENT_DIR}" != *reconciliation_texts* ]]; then
+                  echo "Skipping ${CURRENT_DIR} (not a reconciliation template)"
+                  break
+                fi
                 HANDLE=$(cat ${CURRENT_DIR}/config.json | jq -r ".handle // .name")
                 
                 # Initialize FIRM_ID
@@ -156,28 +170,49 @@ jobs:
                   echo "Using first available firm ID: ${FIRM_ID}"
                 fi
                 
-                if [[ "${CURRENT_DIR}" == *reconciliation_texts* ]]; then
-                  # FETCH THE NEWEST VERSION OF THE TOKENS FROM THE SECRETS, IN CASE THEY WERE UPDATED BY THE INITIATION OF A CONCURRENT WORKFLOW
-                  echo '${{ secrets.CONFIG_JSON }}' > $HOME/.silverfin/config.json
-                  # RUN TEST
-                  echo "Running tests for ${HANDLE} in firm ${FIRM_ID}"
-                  OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --handle "${HANDLE}" --firm "${FIRM_ID}" --status 2>&1)
-                  # CHECK OUTPUT
-                  if [[ "$OUTPUT" =~ "PASSED" ]]; then
-                    echo "${HANDLE}: passed"
-                  elif [[ "$OUTPUT" =~ "FAILED" ]]; then
-                    echo "${HANDLE}: failed"
-                    ERRORS+=("${HANDLE}")
-                  else
-                    echo "${HANDLE}: other errors: ${OUTPUT}"
-                    ERRORS+=("${OUTPUT}")
-                  fi
-                fi
+                # Group this reconciliation under its resolved firm so all reconciliations
+                # for the same firm can be run together in a single parallel batch later.
+                FIRM_HANDLES["${FIRM_ID}"]+=" ${HANDLE}"
+                echo "Queued ${HANDLE} for firm ${FIRM_ID}"
                 break
               else
                 echo "Config file not found in ${CURRENT_DIR}"
                 CURRENT_DIR="$(dirname "${CURRENT_DIR}")"
               fi
+            done
+          done
+          # Run the queued reconciliations grouped per firm. All handles passed to a single
+          # `run-test --status` call are executed concurrently by the CLI (Promise.all), so we
+          # cap each batch at MAX_PARALLEL handles and run batches sequentially to keep the
+          # total number of in-flight tests against the live platform bounded.
+          for FIRM_ID in "${!FIRM_HANDLES[@]}"; do
+            # Deduplicate and sort the handles queued for this firm.
+            read -r -a HANDLES <<< "$(printf '%s\n' ${FIRM_HANDLES[$FIRM_ID]} | sort -u | tr '\n' ' ')"
+            TOTAL=${#HANDLES[@]}
+            echo "Firm ${FIRM_ID}: ${TOTAL} reconciliation(s) to test: ${HANDLES[*]}"
+            for (( START=0; START<TOTAL; START+=MAX_PARALLEL )); do
+              BATCH=("${HANDLES[@]:START:MAX_PARALLEL}")
+              echo "Running batch for firm ${FIRM_ID} (${#BATCH[@]} in parallel): ${BATCH[*]}"
+              if OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --firm "${FIRM_ID}" --status --handle "${BATCH[@]}" 2>&1); then
+                BATCH_EXIT=0
+              else
+                BATCH_EXIT=$?
+              fi
+              echo "${OUTPUT}"
+              # Strip ANSI colour codes so the per-handle status lines can be parsed reliably.
+              CLEAN_OUTPUT=$(printf '%s\n' "${OUTPUT}" | sed -E "s/\x1b\[[0-9;]*m//g")
+              # The CLI prints one top-level "<handle>: PASSED" / "<handle>: FAILED" line per handle.
+              for HANDLE in "${BATCH[@]}"; do
+                if printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "^[[:space:]]*${HANDLE}: PASSED[[:space:]]*$"; then
+                  echo "${HANDLE}: passed"
+                elif printf '%s\n' "${CLEAN_OUTPUT}" | grep -qE "^[[:space:]]*${HANDLE}: FAILED[[:space:]]*$"; then
+                  echo "${HANDLE}: failed"
+                  ERRORS+=("${HANDLE}")
+                else
+                  echo "${HANDLE}: status could not be determined (batch exit code ${BATCH_EXIT})"
+                  ERRORS+=("${HANDLE}")
+                fi
+              done
             done
           done
           # CHECK ERRORS PRESENT

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,11 +24,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Emit non-ASCII paths raw
-        # With git's default core.quotepath=true, paths with non-ASCII characters (e.g. a curly
-        # apostrophe in an account template name) are emitted octal-escaped and silently dropped
-        # by the changed-files glob filter, so the template would never be tested.
-        run: git config --global core.quotepath false
       - name: Get changed liquid files
         id: changed-files
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
@@ -42,9 +37,14 @@ jobs:
           # safe_output: false stops backslash-escaping of shell metacharacters (& ( ) ...) inside
           # the JSON values, which is invalid JSON and would silently empty the template list.
           # Safe here: the list is passed via env and parsed with jq, never eval'd by the shell.
+          # quotepath: false emits paths with non-ASCII characters (e.g. a curly apostrophe in an
+          # account template name) as-is; the action defaults this to true, which octal-escapes
+          # them so they no longer match the glob and the template is silently dropped (setting
+          # git's global core.quotepath does not help - the action overrides it from this input).
           json: true
           escape_json: false
           safe_output: false
+          quotepath: false
           files: |
             **/**.{liquid,yml,yaml,json}
       - name: Filter templates changed


### PR DESCRIPTION
## What this does

Two things:

1. **Runs the liquid tests in parallel** instead of one template at a time.
2. **Also tests account templates**, not just reconciliations.

The silverfin-cli can already run several templates in a single `run-test --status` call (it runs them at the same time via `Promise.all`). The workflow wasn't using that - it called the CLI once per template in a bash loop. Now we group the changed templates and run each group in one call.

## Account templates (new)

Before this PR only `reconciliation_texts` were tested. The CLI can also test `account_templates` (`--account-template`), and a repo like `be_market` has 20 of them that were never run in CI.

This was confirmed on the current `@main` workflow: see silverfin/be_market#2950, where a PR that changes only an account template **skips the test job entirely** - the template isn't even detected (the old filter only matches `reconciliation_texts|shared_parts`, and the old test step only ran `reconciliation_texts`).

This PR tests them the same way as reconciliations. The CLI takes one firm and one template type per call, so templates are grouped by `<firm>|<type>` and each group is one call. Account template folder names contain spaces and characters like `& ( ) '`, so the whole path is made space-safe: the changed-files list is passed around as JSON, config reads are quoted, and the output is matched by exact template name instead of a regex.

## Bugs we found and fixed along the way

- **Shared-parts-only PRs crashed the test step.** The old workflow resolved a firm for every changed template, but shared parts have `.id` as a plain string (not a firm -> id map), so `jq` errored and aborted the step. We now decide the template type first and skip anything without liquid tests.
- **Names with `&`, `(` or `)` silently skipped all tests.** `tj-actions/changed-files` defaults (`escape_json`, `safe_output`) backslash-escape the JSON values, which makes them invalid JSON - `jq` failed, the template list came out empty, and the job skipped while staying green. Fixed with `escape_json: false` + `safe_output: false` (safe: the list is parsed with `jq`, never eval'd by the shell), and the filter now **fails loudly** if the JSON can't be parsed, so this class of bug can't silently skip tests again.
- **Names with non-ASCII characters were silently dropped.** A folder like `...creditnota's` (curly apostrophe) was emitted octal-escaped and never matched the changed-files glob - so the template was never tested. Fixed with the changed-files action's `quotepath: false` input (its own default overrides git's global `core.quotepath`, so the input is the knob that matters).
- **Templates with an empty test YAML were reported as FAILED.** The CLI returns FAILED when the test file has no content, but a template without tests shouldn't fail CI. The workflow now skips those before queuing ("no liquid tests defined").

## Details

- Firm is resolved with the existing rules (`test_firm_id` -> `SF_TEST_FIRM_ID` -> first key of `.id`).
- Each group runs in batches capped at `MAX_PARALLEL_TESTS` (default 10), batches run one after another, so no more than that many tests run at once (the CLI has no rate limiting).
- `run-test --status` exits 0 even when a test fails, so we read the `<name>: PASSED/FAILED` lines from stdout and fail the job if any failed. In CI consola prefixes those lines with `[log] ` and the spinner interleaves frames, so the output is normalised before parsing (trailing whitespace is tolerated too).
- Shared parts are excluded in the detection step, so a shared-parts-only PR skips the test job entirely.
- Each parallel batch is folded into a `::group::` log block, and the job ends with a flat summary: every template with its status and firm, plus a failed/passed count.

## Dropped: per-template re-read of CONFIG_JSON (intentional)

The old loop re-wrote `$HOME/.silverfin/config.json` from the secret before every template, "in case the tokens were updated by a concurrent workflow". That was a no-op: secrets are resolved when the job starts, so it kept writing the same value. It also wouldn't help mid-batch now that templates run in parallel. The config is loaded once at job start; keeping tokens fresh is handled separately (scheduled refresh).

## How to test (for reviewers)

The reusable workflow can't run on its own - a template repo has to call it. To test this branch end to end:

1. In a template repo (e.g. `be_market`), point the ref at this branch in `.github/workflows/run_tests.yml`:
   `uses: silverfin/bso_github_actions/.github/workflows/run_tests.yml@run_tests_in_parallel`
2. On a throwaway branch, add a no-op change to a few templates so they get picked up - e.g. a `{% comment %} test {% endcomment %}` line in their `main.liquid`. Touch both reconciliations and account templates to cover both types.
3. Add the `no-test-required` label so the unrelated `check_tests` check stays green.
4. Open a PR and look at the **Run liquid tests** run. Each batch shows as a collapsible group (`firm 542 · reconciliationText · 3 in parallel`) and the job ends with a per-template summary.

## Before / after (live runs on be_market)

**Before - current `@main`:** silverfin/be_market#2950 - changes only an account template. The `test-templates` job is **skipped**; account templates are not detected or tested today.

**After - this branch:** silverfin/be_market#2949 - tests both types at once, grouped per firm, including the hard names (`Leningen & Leasings (42)`, the non-ASCII `creditnota's` folder) and an empty-YAML template that is now skipped instead of failing.

## Follow-ups (not in this PR)

- Cross-firm parallelism with a GitHub matrix, for PRs that touch many firms.
- silverfin-cli hardening (separate repo):
  - make the spinner a no-op when not on a TTY, so this workflow can drop its output scrubbing;
  - emit a distinct `SKIPPED`/`NO_TESTS` status for templates with an empty test YAML instead of `FAILED`;
  - non-zero exit code on FAILED, a concurrency cap on `Promise.all`, and isolating a single hard error instead of `process.exit(1)` killing the whole batch.
