### PR TITLE
push_to_review_firm.yml: strip refreshToken to stop silent CONFIG_JSON poisoning

### DIFF
--- a/.github/workflows/push_to_review_firm.yml
+++ b/.github/workflows/push_to_review_firm.yml
@@ -165,7 +165,7 @@ jobs:
           echo '${{ secrets.CONFIG_JSON }}' > "$HOME/.silverfin/config.json"
           # Blank every firm's refreshToken so an expired access token fails cleanly on a 401
           # instead of silently rotating (and poisoning) the shared CONFIG_JSON secret this
-          # workflow never writes back to. See CI_AUTH_SAMPLER_PLAN.md §8.
+          # workflow never writes back to.
           jq 'to_entries | map(if (.key|test("^[0-9]+$")) then .value.refreshToken = "" else . end) | from_entries' \
             "$HOME/.silverfin/config.json" > "$HOME/.silverfin/config.stripped.json"
           mv "$HOME/.silverfin/config.stripped.json" "$HOME/.silverfin/config.json"

--- a/.github/workflows/push_to_review_firm.yml
+++ b/.github/workflows/push_to_review_firm.yml
@@ -163,6 +163,12 @@ jobs:
         run: |
           mkdir -p "$HOME/.silverfin"
           echo '${{ secrets.CONFIG_JSON }}' > "$HOME/.silverfin/config.json"
+          # Blank every firm's refreshToken so an expired access token fails cleanly on a 401
+          # instead of silently rotating (and poisoning) the shared CONFIG_JSON secret this
+          # workflow never writes back to. See CI_AUTH_SAMPLER_PLAN.md §8.
+          jq 'to_entries | map(if (.key|test("^[0-9]+$")) then .value.refreshToken = "" else . end) | from_entries' \
+            "$HOME/.silverfin/config.json" > "$HOME/.silverfin/config.stripped.json"
+          mv "$HOME/.silverfin/config.stripped.json" "$HOME/.silverfin/config.json"
           node ./node_modules/silverfin-cli/bin/cli.js config --set-firm="${FIRM_ID}"
           node ./node_modules/silverfin-cli/bin/cli.js config --get-firm
 


### PR DESCRIPTION
## Problem

`push_to_review_firm.yml` (#24) documents itself as read-only on `CONFIG_JSON` — "never refreshes tokens and never writes the secret back." That's true of the workflow script, but not of the silverfin-cli it shells out to: `axiosFactory.js`'s response interceptor transparently refreshes the access token on **any** 401, for **any** command, and persists the rotated pair only to the local `~/.silverfin/config.json` on the runner (discarded when the job ends).

Since this workflow is dispatched frequently and at unpredictable times (a Jira button, not tied to PR activity) and is chatty against one firm (per-template updates + a full `add-shared-part --all` sweep), a run whose access token happens to be near/at its ~2h expiry silently rotates the refresh token server-side and throws the new pair away — leaving `CONFIG_JSON` holding an already-consumed refresh token. The next thing to use it (`check_auth.yml`'s explicit refresh, the secret's sole writer) gets `invalid_grant`.

This is what happened to firm 400583 twice in two days (`be_market` runs `29314984998`/`29318715898`, 2026-07-14). Fixed manually via re-authorization, but the mechanism was still live.

## Fix

Blank every firm's `refreshToken` in the loaded local config before any CLI command runs (same mechanism already validated for the read-only test-runner in `be_market`'s `run_tests_TEST.yml`). Effect:
- Valid token → nothing changes, push succeeds as before.
- Stale token → the CLI's 401 handler sends an empty refresh token, Silverfin rejects it cleanly, the job fails with a legible error instead of silently rotating anything. `CONFIG_JSON`'s real refresh token is never touched.

Trades "silently corrupts a secret shared by every other consumer" for "this one push occasionally needs a retry."

## Validation

Live-tested against `be_market` (throwaway PR #3028, closed after validation; firm 1355):
- **Happy path** (valid token): pushed clean, PR comment correct.
- **Forced 401** (deliberately invalid access token, test-only commit never merged): failed cleanly (`400 Bad Request` / "Error refreshing credentials"), PR comment showed the failure legibly.
- **No-poison check**: immediately after the forced failure, triggered a real `check_auth.yml` refresh — all 8 firms in `be_market`'s `CONFIG_JSON`, including 1355, refreshed successfully. The forced-401 run never touched the real secret.

## Not in scope here (tracked separately)
- Porting the same strip into `test-templates` (`run_tests.yml`) — same theoretical exposure, not yet exercised hard enough to manifest.
- A `be_market`-local scheduled refresh wrapper to shrink the staleness window further (optional reliability improvement, not a correctness requirement — this fix is safe without it).
- The unrelated "Find open PRs" branch-matching failure hit in the same incident window.