### PR TITLE
fix: validate token shape before treating post-run config as rotated

### DIFF
--- a/.github/workflows/run_sampler.yml
+++ b/.github/workflows/run_sampler.yml
@@ -266,6 +266,10 @@ jobs:
           fi
           AFTER_TOKEN=$(jq -r --arg p "${PARTNER}" '.partnerCredentials[$p].token' "$HOME/.silverfin/config.json")
           echo "::add-mask::${AFTER_TOKEN}"
+          if ! jq -e --arg p "${PARTNER}" '(.partnerCredentials[$p].token | type == "string" and length > 0)' "$HOME/.silverfin/config.json" > /dev/null 2>&1; then
+            echo "::error::Partner ${PARTNER} config.json has no valid token after the run — refusing to write back a possibly broken config."
+            exit 1
+          fi
           if [[ "${AFTER_TOKEN}" == "${BEFORE_TOKEN}" ]]; then
             echo "Partner token unchanged — no write-back needed (sole-writer secret stays untouched)."
             exit 0


### PR DESCRIPTION
## Summary

`run_sampler.yml`'s "Capture partner token after the run and write back if rotated" step reads `AFTER_TOKEN` via `jq -r` and compares it directly to `BEFORE_TOKEN`, without checking it's actually a non-empty string first — unlike the earlier "Load PARTNER_CONFIG_JSON" step, which does validate shape before proceeding.

If `config.json` ends up missing `partnerCredentials[partner].token` after the run (e.g. a partial/crashed write by the CLI), `jq -r` prints the literal string `"null"`, which differs from `BEFORE_TOKEN` and reads as "rotated" — triggering an unconditional `gh secret set` that overwrites the good secret with a broken config. Since `PARTNER_CONFIG_JSON_<partner>` has no other writer, that's an unrecoverable regression for that partner until someone manually re-authorizes it.

Fix: validate the post-run token's shape the same way the load step already does, and fail closed (refuse to write back) rather than silently corrupting the secret.

## How this was found

Flagged by CodeRabbit while nl_market and lu_market temporarily inlined this job into their own wrapper workflows (unrelated experiment - installing silverfin-cli from a branch instead of `main` to gather feedback on a different change). This reusable workflow is the actual upstream source both copies inherited the bug from - already fixed in both:
- https://github.com/silverfin/nl_market/pull/893
- https://github.com/silverfin/lu_market/pull/765

## Test plan
- [x] YAML validated (`ruby -ryaml`, `actionlint` - one pre-existing `queue: max` false positive unrelated to this change)
- [ ] No CI in this repo to run automatically; safe to review directly, minimal 4-line diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)