### PR TITLE
Add gh auth preflight check to authorize-partner-secret.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,11 @@ One-off setup script that authorizes a partner `api_key` against staging and sto
 _Prerequisites:_
 
 * `silverfin` CLI installed and on `PATH`.
-* `gh` CLI installed and authenticated (`gh auth login`), with write access to the target market repo's secrets.
+* `gh` CLI installed and authenticated, with write access to the target market repo's secrets. Check this **before** you get a fresh token below — a bad `gh` session is a common failure mode (expired token, or needing to re-run `gh auth login` after a while):
+  ```bash
+  gh auth status
+  ```
+  If that doesn't show a valid logged-in account, run `gh auth login` and check again. The script also checks this itself right before it would need it, and prints these same steps if it isn't set up — but confirming it upfront saves you from going through the staging login flow below only to hit an avoidable failure at the very last step.
 * A fresh partner `api_key`, obtained via the staging login flow below. Get this **right before** running the script — the token is shown once, in a banner, and you paste it straight into the prompt.
 
 _Getting the partner `api_key` (staging login flow):_
@@ -318,7 +322,7 @@ _Usage:_
 ```
 
 * `<partner_id>` — numeric partner environment id, e.g. `2`.
-* `<market>` — either a short code (`nl`, `be`, `lu`, `uk`, mapped to `silverfin/<market>_market` in the script's `MARKET_REPOS` table) or a full `owner/repo`.
+* `<market>` — either a short code (`nl`, `be`, `lu`, `uk`, mapped to `silverfin/<market>_market` by the script's market → repo lookup) or a full `owner/repo`.
 * `[host]` — optional. Defaults to `https://bso-staging-beta.staging.getsilverfin.com` (the same staging beta host used in the login flow above). Pass an explicit URL to target a different environment, or edit the `HOST` default in the script if you're permanently moving to a new environment.
 
 Examples:
@@ -332,6 +336,7 @@ Examples:
 
 _What it does:_
 
+* Resolves `<market>` to a repo, then checks `gh auth status` — exits immediately with the `gh auth login` steps above if it's not valid, before asking for anything sensitive.
 * Prompts for the api key (hidden input).
 * Creates a throwaway `HOME` directory so the authorization doesn't touch your real `~/.silverfin/config.json`.
 * Runs `silverfin config --set-host <host>` and `silverfin authorize-partner -i <partner_id> -k <api_key> -n partner-<partner_id>` inside that throwaway `HOME`.

--- a/scripts/authorize-partner-secret.sh
+++ b/scripts/authorize-partner-secret.sh
@@ -34,6 +34,18 @@ HOST="${3:-https://bso-staging-beta.staging.getsilverfin.com}"
 
 REPO="$(market_repo "$MARKET")"
 
+if ! gh auth status >/dev/null 2>&1; then
+  cat >&2 <<MSG
+gh is not authenticated (or its stored token is invalid/expired) — the
+final step of this script (gh secret set) would fail on ${REPO}.
+
+Fix it, then re-run this script:
+  1. gh auth login
+  2. gh auth status   # confirm it now shows a valid logged-in account
+MSG
+  exit 1
+fi
+
 printf '%s' "API key for partner ${PARTNER_ID} (${REPO}): "
 read -rs API_KEY
 echo


### PR DESCRIPTION
## Summary
Stacked on #33 (bash 3.2 fix). Two real hiccups came up while rolling this script out:
- macOS's bash 3.2 (fixed in #33)
- A stale/expired `gh` session — this only surfaced as `HTTP 401: Bad credentials` at the very last step (`gh secret set`), after already going through the full staging login flow to get a fresh partner token.

This adds a `gh auth status` preflight check right after resolving the target repo, before the script ever prompts for the sensitive api key — so a bad `gh` session fails fast with the fix steps instead of wasting a token/login cycle. Also documents checking `gh auth status` proactively in the README, and fixes a stale `MARKET_REPOS` table reference left over from #33's refactor.

## Test plan
- [x] Ran full script on bash 3.2 with a fake failing `gh auth status` — exits immediately with the `gh auth login` steps, before any prompt
- [x] Ran full script on bash 3.2 with a fake succeeding `gh auth status` and fake `silverfin`/`gh` — proceeds through normally
- [ ] One real run against a real market repo with a real partner token, to confirm the preflight doesn't false-positive on a genuinely valid `gh` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)